### PR TITLE
[iOS] feat: 기록뷰 네비게이션 타이틀 구현 (#106)

### DIFF
--- a/Mondee/View/CleanRoomView/CleanRoomView.swift
+++ b/Mondee/View/CleanRoomView/CleanRoomView.swift
@@ -23,17 +23,17 @@ struct CleanRoomView: View {
                 .frame(height: scrollViewOffset > 0 ? scrollViewOffset : 0)
             ScrollView {
                 VStack {
-                    LargeNavigationTitle(scrollViewOffset: $scrollViewOffset)
+                    LargeNavigationTitle(scrollViewOffset: $scrollViewOffset,title: "멸균실",subTitle: "획득한 먼지들을 확인해보세요")
                     
                     LatestCollectedMondeeView(collectedModel: collectedModel)
                     
                     CollectedMondeeGridView(isDetailCardPopUp: $isDetailCardPopUp, collected: $collectedMondee, collectedModel: collectedModel)
                 }
             }
-            .safeAreaInset(edge: .bottom) { Color.clear.frame(height: 43) }
-            .safeAreaInset(edge: .top) { Color.clear.frame(height: 30) }
+            .safeAreaInset(edge: .bottom) { Color.clear.frame(height: 0) }
+            .safeAreaInset(edge: .top) { Color.clear.frame(height: 0) }
             .overlay(alignment: .top) {
-                InlineNavigationTitle(scrollViewOffset: scrollViewOffset)
+                InlineNavigationTitle(scrollViewOffset: scrollViewOffset,title: "멸균실")
             }
             .blur(radius: isDetailCardPopUp ? 2 : 0)
             
@@ -46,16 +46,18 @@ struct CleanRoomView: View {
 }
 
 struct LargeNavigationTitle: View {
-    
     @Binding var scrollViewOffset: CGFloat
+    
+    let title: String
+    let subTitle: String
     
     var body: some View {
         VStack(alignment: .leading, spacing: 5) {
-            Text("멸균실")
+            Text(title)
                 .font(.title)
                 .fontWeight(.bold)
                 .foregroundColor(.mondeeBlue)
-            Text("획득한 먼지들을 확인해보세요")
+            Text(subTitle)
         }
         .frame(maxWidth: .infinity, alignment: .leading)
         .opacity(Double(scrollViewOffset / 40 - 0.65))
@@ -73,12 +75,13 @@ struct LargeNavigationTitle: View {
 }
 
 struct InlineNavigationTitle: View {
-    
     var scrollViewOffset: CGFloat
+    
+    let title: String
     
     var body: some View {
         VStack(alignment: .leading) {
-            Text("멸균실")
+            Text(title)
                 .font(.title3)
                 .fontWeight(.bold)
                 .foregroundColor(.mondeeBlue)

--- a/Mondee/View/RecordView/RecordTitleArea.swift
+++ b/Mondee/View/RecordView/RecordTitleArea.swift
@@ -8,41 +8,35 @@
 import SwiftUI
 
 struct RecordTitleArea: View {
+    @Binding var scrollViewOffset: CGFloat
     
     @ObservedObject var userData: UserData
-
+    
     var body: some View {
         
         /// 최대 연속 횟수 확인 maxConsecutiveSuccessCount 사용
         let (recentConsecutiveSuccessCount, _) = userData.consecutiveSuccessCounts()
         
-        RoundedRectangle(cornerRadius: 20)
-            .frame(maxWidth: .infinity)
-            .frame(height: 164)
-            .foregroundColor(Color.mondeeBoxBackground)
-            .shadow(color: .black.opacity(0.05), radius: 4, x: 0, y: 4)
-            .overlay(alignment: .leading){
-                VStack(alignment: .leading, spacing: 0){
-                    Spacer()
-                    Text("연속 성공 \(recentConsecutiveSuccessCount)일차🎉")
-                        .font(.system(size: 27, weight: .bold))
-                        .padding(.bottom,7)
-                    Text("성공 버블을 모아보세요")
-                        .font(.system(size: 16, weight: .regular))
-                        .foregroundColor(Color.mondeeGrey)
-                        .padding(.bottom, 20)
-                }
-                .padding(.leading, 40)
-            }
-            
-    }
-}
-
-struct RecordTitleArea_Previews: PreviewProvider {
-    static var previews: some View {
-        ZStack{
-            Color.mondeeBackgroundGrey.ignoresSafeArea()
-            RecordTitleArea(userData: UserData())
+        
+        VStack(alignment: .leading, spacing: 5) {
+            Text("연속 성공 \(recentConsecutiveSuccessCount)일차🎉")
+                .font(.title)
+                .fontWeight(.bold)
+                .foregroundColor(.black)
+            Text("성공 버블을 모아보세요")
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .opacity(Double(scrollViewOffset / 40 - 0.65))
+        .padding(EdgeInsets(top: 0, leading: 40, bottom: 20, trailing: 40))
+        .background(
+            RoundedRectangle(cornerRadius: 20, style: .continuous)
+                .fill(Color.mondeeBoxBackground)
+                .edgesIgnoringSafeArea(.top)
+                .shadow(color: .black.opacity(0.05), radius: 4, y: 4)
+        )
+        .onScrollViewOffsetChanged { value in
+            scrollViewOffset = value
         }
     }
 }
+

--- a/Mondee/View/RecordView/RecordView.swift
+++ b/Mondee/View/RecordView/RecordView.swift
@@ -12,36 +12,35 @@ struct RecordView: View {
     @State private var scrollViewOffset: CGFloat = 0
     
     @State var currentMonth : Int = 0 // 화살표 클릭으로 인한 월 세는 변수
-        
-    @StateObject var userData = UserData()
+    
+    @ObservedObject var userData = UserData()
+    
     
     var body: some View {
         
         ZStack(alignment: .top){
-            VStack {
-                Color.mondeeBoxBackground
-                Color.mondeeBackgroundGrey
-            }
+            Color.mondeeBoxBackground.ignoresSafeArea()
+                .frame(height: scrollViewOffset > 0 ? scrollViewOffset : 0)
+            
             ScrollView{
-                ZStack {
-                    Color.mondeeBackgroundGrey.padding(.top, 25)
-                    VStack(spacing: 13){
-                        RecordTitleArea(userData: userData)
-                        VStack(spacing: 15){
-                            RecordCalendarArea(currentDate: $currentDate, currentMonth: $currentMonth)
-                            MonthStatistics(userData: userData, currentMonth: $currentMonth)
-                            TotalStatistics(userData: userData)
-                        }
-                        .padding(.horizontal, 16)
+                
+                VStack(spacing: 15){
+                    RecordTitleArea(scrollViewOffset: $scrollViewOffset, userData: userData)
+                    VStack(spacing: 15){
+                        RecordCalendarArea(currentDate: $currentDate, currentMonth: $currentMonth)
+                        MonthStatistics(userData: userData, currentMonth: $currentMonth)
+                        TotalStatistics(userData: userData)
                     }
+                    .padding(.horizontal, 16)
                 }
+                
             }
-            .safeAreaInset(edge: .bottom) { Color.clear.frame(height: 43) }
-            Rectangle().frame(height: 60)
-                .foregroundColor(.mondeeBoxBackground)
+            .safeAreaInset(edge: .bottom) { Color.clear.frame(height: 0) }
+            .safeAreaInset(edge: .top) { Color.clear.frame(height: 0) }
+            .overlay(alignment: .top) {
+                InlineNavigationTitle(scrollViewOffset: scrollViewOffset,title: "기록실")
+            }
         }
-        .edgesIgnoringSafeArea(.all)
-
     }
 }
 


### PR DESCRIPTION
## 📌 Summary
<!-- 이슈 및 번호 (optional)
     이슈가 없다면 이 작업을 하게 된 이유 
     작업 내용 요약 -->
#106 
<br>

## ✨ Description
<!-- 작업 내용 (스크린샷도 같이 있으면 좋아요) -->
스크롤 하였을때 기록뷰가 네비게이션 타이틀에 글자가 생깁니다.
<br>

## 🏷️ Reference (optional)
<!-- 참고사항이나 레퍼런스 -->

<br>

## Screenshot
<!-- img src "이부분에 gif파일 넣어주시면 됩니다" -->
|기능|스크린샷|
|:--:|:--:|
|GIF|<img src = "https://github.com/DeveloperAcademy-POSTECH/MC3-Team5-Mondee/assets/114594496/79c36779-293a-4824-a472-e37d2ce1354b" width ="250">|

<br>

## 🗒️ Note (optional)
<!-- 추가 필요한 사항이나 하고픈 말
     Reviewer 한테 요청하고 싶은 것들
     코드리뷰 요청하고 싶은 것들.. 등등 -->
