### PR TITLE
[iOS] feat: Navigation Stack 기능 구현 (#128)

### DIFF
--- a/Mondee/View/CustomTabView.swift
+++ b/Mondee/View/CustomTabView.swift
@@ -64,6 +64,7 @@ struct CustomTabView: View {
                     .transition(.opacity)
             }
         }
+        .tint(.clear)
     }
 }
 

--- a/Mondee/View/TodayView/ShareView.swift
+++ b/Mondee/View/TodayView/ShareView.swift
@@ -126,7 +126,6 @@ struct ShareView: View {
             }
             .padding()
         }
-        .navigationBarBackButtonHidden()
         .toolbar {
             ToolbarItem(placement: .navigationBarLeading, content: {
                 Button {
@@ -134,7 +133,8 @@ struct ShareView: View {
                 } label: {
                     Image(systemName: "chevron.left")
                         .foregroundColor(.mondeeGrey)
-                        .padding(.leading, 5)
+                        .fontWeight(.semibold)
+                        .padding(.leading, -30)
                 }
 
             })


### PR DESCRIPTION
## 📌 Summary
<!-- 이슈 및 번호 (optional)
     이슈가 없다면 이 작업을 하게 된 이유 
     작업 내용 요약 -->
- ShareView 에서 기존에 버튼으로만 작용하던 navigation back button을 드래그로도 가능하게 수정하였습니다.

<br>

## ✨ Description
<!-- 작업 내용 (스크린샷도 같이 있으면 좋아요) -->

<br>

## 🏷️ Reference (optional)
<!-- 참고사항이나 레퍼런스 -->

<br>

## Screenshot
<!-- img src "이부분에 gif파일 넣어주시면 됩니다" -->
|기능|스크린샷|
|:--:|:--:|
|네비게이션 기능|<img src = "https://github.com/DeveloperAcademy-POSTECH/MC3-Team5-Mondee/assets/120548537/c2c4a7c4-695a-4141-99d2-493bc4319695" width ="250">|


<br>

## 🗒️ Note (optional)
<!-- 추가 필요한 사항이나 하고픈 말
     Reviewer 한테 요청하고 싶은 것들
     코드리뷰 요청하고 싶은 것들.. 등등 -->
